### PR TITLE
[DOC REVIEW] load_project.ipynb: fix demo repo name in Git URL [IG-13721]

### DIFF
--- a/load_project.ipynb
+++ b/load_project.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "You can also clone the code into a dir using a CLI commands:\n",
     "\n",
-    "`mlrun project my-proj/ -u git://github.com/mlrun/demo-xgb-project.git`\n"
+    "`mlrun project my-proj/ -u git://github.com/mlrun/demo-image-classification.git`\n"
    ]
   },
   {


### PR DESCRIPTION
The Git clone command in the NB doc referred to the `demo-xgboost repo` instead of the `demo-image-classification` repo.

@yaronha I think we need to have `development` branches in the mlrun demo repos; I don't have permissions to create such branches myself.